### PR TITLE
Fix post creation issue

### DIFF
--- a/prisma/migrations/20250930124400_update_post_schema/migration.sql
+++ b/prisma/migrations/20250930124400_update_post_schema/migration.sql
@@ -1,0 +1,26 @@
+-- Update Post table to match current Prisma schema
+-- 1) Rename column "name" -> "trackId" (only if present)
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'Post'
+      AND column_name = 'name'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'Post'
+      AND column_name = 'trackId'
+  ) THEN
+    ALTER TABLE "Post" RENAME COLUMN "name" TO "trackId";
+  END IF;
+END $$;
+
+-- 2) Add optional content column (idempotent)
+ALTER TABLE "Post" ADD COLUMN IF NOT EXISTS "content" TEXT;
+
+-- 3) Ensure index on trackId; drop old index if it exists
+DROP INDEX IF EXISTS "Post_name_idx";
+CREATE INDEX IF NOT EXISTS "Post_trackId_idx" ON "Post"("trackId");
+


### PR DESCRIPTION
Add Prisma migration to rename `Post.name` to `trackId` and add `content` column to fix post creation issues.

The application code expects `Post.trackId` and `Post.content`, but the existing database schema (from an initial migration) only had `Post.name`. This mismatch caused errors when creating posts. This migration resolves the schema discrepancy.

---
<a href="https://cursor.com/background-agent?bcId=bc-2cf76b00-24b6-4579-ab7f-d51ea2c7dc0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2cf76b00-24b6-4579-ab7f-d51ea2c7dc0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prisma migration updates `Post` table: conditionally rename `name`→`trackId`, add `content`, and switch index from `name` to `trackId`.
> 
> - **Database (Prisma migration)**:
>   - Rename `Post.name` → `Post.trackId` (idempotent conditional).
>   - Add optional `Post.content` column.
>   - Drop `Post_name_idx`; create `Post_trackId_idx` on `trackId`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5d96d6f4c3afc202c59177181bcb310651bc13f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->