### PR TITLE
Troubleshoot playback and device discovery

### DIFF
--- a/QUICK_FIX_INSTRUCTIONS.md
+++ b/QUICK_FIX_INSTRUCTIONS.md
@@ -1,0 +1,58 @@
+# 🚀 Quick Fix Instructions
+
+## Problem Summary
+You're missing 3 OAuth scopes (`user-read-currently-playing`, `user-read-recently-played`, `streaming`) because your database has an old account record from before these scopes were added to the code.
+
+## ⚡ Quick Fix (30 seconds)
+
+1. Go to your deployed app: `https://from-the-morning.vercel.app/diagnostics`
+2. Wait for diagnostics to run automatically
+3. Look for the red **"Force Re-Authentication"** button in the "Quick Actions" section
+4. Click it and confirm
+5. You'll be signed out automatically
+6. Sign back in with Spotify
+7. Grant all permissions when prompted
+8. Done! Check diagnostics again to verify
+
+## What Changed
+
+### New Files Added:
+- `/src/pages/api/debug/force-reauth.ts` - API endpoint to safely delete account and force re-auth
+- `SPOTIFY_TROUBLESHOOTING_SOLUTION.md` - Comprehensive troubleshooting guide
+- This file!
+
+### Files Modified:
+- `/src/pages/diagnostics.tsx` - Added force re-auth button and better error messages
+
+## What Will Fix:
+✅ Missing OAuth scopes error  
+✅ No devices found issue (after opening Spotify app)  
+✅ Playback control capabilities  
+✅ Streaming functionality  
+
+## After Re-Authentication
+
+Once you've signed in again with new scopes:
+
+1. **Open Spotify** on your phone or computer
+2. **Play any song** (even for 1 second)
+3. **Refresh the diagnostics page**
+4. You should now see devices listed!
+
+## Important Notes:
+- ⚠️ **Spotify Premium is REQUIRED** for playback control
+- The "Force Re-Authentication" button only appears if scopes are missing
+- This is safe - it only deletes YOUR account record, not your Spotify account
+- All your data stays intact; just the OAuth tokens are reset
+
+## Verification Checklist:
+After re-auth, your diagnostics should show:
+- [x] NextAuth Session: ✓ Authenticated
+- [x] Database Account Record: ✓ Has refresh token
+- [x] OAuth Scopes: ✓ All 6 scopes present (no error)
+- [x] Spotify Access Token: ✓ Valid
+- [x] Spotify Devices: ✓ 1+ found (after opening Spotify)
+- [x] Current Playback: ✓ Shows track info (if playing)
+
+## Need More Help?
+See `SPOTIFY_TROUBLESHOOTING_SOLUTION.md` for detailed explanations and advanced troubleshooting.

--- a/SPOTIFY_TROUBLESHOOTING_SOLUTION.md
+++ b/SPOTIFY_TROUBLESHOOTING_SOLUTION.md
@@ -1,0 +1,196 @@
+# 🔧 Spotify Integration Troubleshooting Solution
+
+## 🔍 Issues Identified
+
+Based on your diagnostics screenshots, you're experiencing two related problems:
+
+### 1. **Missing OAuth Scopes** ❌
+- **Missing**: `user-read-currently-playing`, `user-read-recently-played`, `streaming`
+- **Root Cause**: Your database has an old Account record from before these scopes were added to the code
+- **Impact**: Without these scopes, Spotify API calls for playback and device control will fail
+
+### 2. **No Devices Found** ⚠️
+- **Status**: 0 devices available
+- **Primary Cause**: Missing `streaming` scope (see issue #1)
+- **Secondary Causes**: 
+  - No Spotify app actively open/playing
+  - Web Playback SDK hasn't initialized
+  - Account may not have Spotify Premium (required for playback control)
+
+## ✅ Solution Steps
+
+### Option A: Automated Fix (Recommended)
+
+1. **Go to your diagnostics page** at `/diagnostics`
+2. **Click "Run Diagnostics"** to verify the OAuth Scopes error
+3. **Click the red "Force Re-Authentication" button** that appears in the Quick Actions section
+4. **Confirm the action** when prompted
+5. **You'll be automatically signed out** and redirected
+6. **Sign in again with Spotify** - you'll see the new permission requests
+7. **Grant all permissions** when Spotify prompts you
+8. **Return to diagnostics page** to verify all scopes are now present
+
+### Option B: Manual Fix
+
+If you prefer to do it manually:
+
+1. **Sign out** of your application
+2. **Manually delete the Account record** from your database:
+   ```sql
+   DELETE FROM "Account" WHERE "userId" = 'your-user-id';
+   ```
+3. **Sign in again** - NextAuth will create a new Account record with all current scopes
+
+### Option C: Database Direct Update (Not Recommended)
+
+You could theoretically update the `scope` field directly in the database, but this is NOT recommended because:
+- The existing tokens don't have permissions for the new scopes
+- Spotify won't honor the new scopes until you re-authorize
+- You'll still have permission errors
+
+## 🎯 What Fixed Code Does
+
+I've added the following improvements to your diagnostics page:
+
+### 1. **New API Endpoint**: `/api/debug/force-reauth`
+- Safely deletes your account record
+- Provides detailed logging
+- Requires POST method for safety
+- Only deletes YOUR account (based on session)
+
+### 2. **Updated Diagnostics UI**
+- Shows a prominent red "Force Re-Authentication" button when scopes are missing
+- Provides clear instructions in error messages
+- Highlights your specific issue at the top of "Common Issues"
+- Automatically signs you out after forcing re-auth
+
+### 3. **Better Error Messages**
+- OAuth Scopes error now points to the solution button
+- "Common Issues" section highlights the scope problem as your current issue
+- Explains WHY this happens (developer adds scopes, existing users keep old ones)
+
+## 📋 Verification Checklist
+
+After re-authenticating, verify these items on the diagnostics page:
+
+- [ ] ✓ NextAuth Session shows as authenticated
+- [ ] ✓ Database Account Record has refresh token
+- [ ] ✓ OAuth Scopes check passes (no missing scopes error)
+- [ ] ✓ Spotify Access Token retrieved successfully
+- [ ] ✓ Token Status shows "Valid"
+
+## 🎵 Getting Devices to Appear
+
+After fixing the OAuth scopes, to get devices:
+
+### For Desktop/Mobile App:
+1. Open Spotify on your computer or phone
+2. Start playing ANY song (even for 1 second)
+3. Wait 5-10 seconds
+4. Refresh the diagnostics page
+5. You should see your device(s) listed
+
+### For Web Playback SDK:
+1. The SDK initializes when the Player component mounts
+2. It creates a device called "Web Playback SDK" or similar
+3. This requires the `streaming` scope (which you'll have after re-auth)
+4. It may take 5-10 seconds to appear after page load
+
+### Important Notes:
+- **Spotify Premium is REQUIRED** for playback control and Web SDK
+- Free accounts can see devices but cannot control playback
+- Some device types may not be controllable via API
+
+## 🔄 Why This Happens
+
+This is a common OAuth issue when developing applications:
+
+1. You initially created the app with basic scopes
+2. Later, you added more scopes to `src/server/auth.ts`
+3. **Existing database records retained the old scopes**
+4. New users would get the new scopes, but existing users wouldn't
+5. Solution: Force existing users to re-authenticate
+
+## 🛡️ Preventing This In Production
+
+For production applications, when adding new OAuth scopes:
+
+1. **Add a scope version field** to track which scopes users have
+2. **Check scope version on login** and prompt re-auth if outdated
+3. **Gracefully handle missing permissions** with clear user prompts
+4. **Log scope mismatches** for monitoring
+
+Example approach:
+```typescript
+// Check if user needs re-auth
+const needsReauth = !account.scope?.includes('streaming');
+if (needsReauth) {
+  // Show modal: "We've added new features! Please reconnect your Spotify account"
+  // Button: "Reconnect Spotify" -> triggers force-reauth
+}
+```
+
+## 📊 Expected Results After Fix
+
+Once you've re-authenticated with the new scopes:
+
+### Diagnostics Page Should Show:
+```
+✓ NextAuth Session: Authenticated as jack.pickard@hotmail.com
+✓ Database Account Record: Account found with refresh token
+✓ OAuth Scopes: All 6 required scopes present
+✓ Spotify Access Token: Token retrieved successfully
+✓ Spotify Devices: Found 1+ device(s)
+✓ Current Playback State: Playing/Paused (if something is playing)
+```
+
+### You'll Be Able To:
+- See all available Spotify devices
+- Control playback (play, pause, skip)
+- See currently playing track
+- Adjust volume
+- Transfer playback between devices
+
+## 🆘 If Problems Persist
+
+If you still have issues after re-authenticating:
+
+1. **Check Spotify Account Type**
+   - Go to https://www.spotify.com/account/
+   - Verify you have Spotify Premium
+   - Free accounts cannot control playback
+
+2. **Verify Spotify App Settings**
+   - Go to https://developer.spotify.com/dashboard/
+   - Check your app status (should be in "Development" or "Extended Quota Mode")
+   - Verify Redirect URIs match your deployment URL
+
+3. **Check Environment Variables**
+   - Verify `SPOTIFY_CLIENT_ID` is set correctly
+   - Verify `SPOTIFY_CLIENT_SECRET` is set correctly
+   - Verify `NEXTAUTH_SECRET` is set
+   - Verify `NEXTAUTH_URL` matches your deployment URL
+
+4. **Test Raw API Calls**
+   - Use the "Test API Calls" button on diagnostics page
+   - Check the logs for specific error messages
+   - Common errors:
+     - `403 Forbidden`: Premium required
+     - `401 Unauthorized`: Token/scope issue
+     - `404 Not Found`: Endpoint issue
+
+## 📝 Additional Resources
+
+- [Spotify Web API Authorization Guide](https://developer.spotify.com/documentation/web-api/concepts/authorization)
+- [Spotify Web Playback SDK](https://developer.spotify.com/documentation/web-playback-sdk)
+- [NextAuth.js Spotify Provider](https://next-auth.js.org/providers/spotify)
+
+## 🎉 Summary
+
+**Your main issue is stale OAuth scopes.** The fix is simple:
+1. Click "Force Re-Authentication" button
+2. Sign in again
+3. Grant all permissions
+4. Verify scopes are present
+
+This should resolve both the scope error AND the no devices issue.

--- a/src/pages/api/debug/force-reauth.ts
+++ b/src/pages/api/debug/force-reauth.ts
@@ -1,0 +1,94 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "~/server/auth";
+import { db } from "~/server/db";
+
+/**
+ * Force re-authentication by deleting the account record.
+ * This will require the user to sign in again and grant new OAuth scopes.
+ * 
+ * IMPORTANT: This is a debugging tool. Use with caution.
+ */
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed. Use POST." });
+  }
+
+  try {
+    const session = await getServerSession(req, res, authOptions);
+
+    if (!session?.user?.id) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    const logs: string[] = [];
+    logs.push(`[${new Date().toISOString()}] Force re-authentication requested`);
+    logs.push(`User ID: ${session.user.id}`);
+    logs.push(`Email: ${session.user.email ?? "unknown"}`);
+
+    // Check if account exists
+    const account = await db.account.findFirst({
+      where: { userId: session.user.id },
+      select: {
+        id: true,
+        provider: true,
+        scope: true,
+      },
+    });
+
+    if (!account) {
+      logs.push("❌ No account found to delete");
+      return res.status(404).json({ 
+        error: "No account found",
+        logs 
+      });
+    }
+
+    logs.push(`✓ Found account: ${account.provider}`);
+    logs.push(`  Current scopes: ${account.scope ?? "none"}`);
+    logs.push(`  Account ID: ${account.id}`);
+
+    // Delete the account record
+    logs.push("\n--- Deleting account record ---");
+    await db.account.delete({
+      where: { id: account.id },
+    });
+    logs.push("✓ Account record deleted successfully");
+
+    // Verify deletion
+    const verifyAccount = await db.account.findFirst({
+      where: { userId: session.user.id },
+    });
+
+    if (verifyAccount) {
+      logs.push("⚠️ Warning: Account still exists after deletion attempt");
+      return res.status(500).json({ 
+        error: "Failed to delete account",
+        logs 
+      });
+    }
+
+    logs.push("✓ Verified: Account successfully removed");
+    logs.push("\n--- Next Steps ---");
+    logs.push("1. Sign out from the application");
+    logs.push("2. Sign in again with Spotify");
+    logs.push("3. Grant all requested permissions");
+    logs.push("4. Run diagnostics again to verify new scopes");
+
+    return res.status(200).json({
+      success: true,
+      message: "Account deleted. Please sign out and sign in again.",
+      timestamp: new Date().toISOString(),
+      logs,
+    });
+  } catch (error) {
+    console.error("Error in force re-auth:", error);
+    return res.status(500).json({ 
+      error: "Internal server error",
+      message: error instanceof Error ? error.message : "Unknown error"
+    });
+  }
+}


### PR DESCRIPTION
Add a "Force Re-Authentication" feature and troubleshooting guides to resolve Spotify OAuth scope and device discovery issues.

Existing users' database records retain old OAuth scopes even after new scopes are added to the application code. This PR provides a user-friendly mechanism on the diagnostics page to delete the stale account record, forcing re-authentication to grant all necessary permissions for full Spotify integration functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-2e072f63-0b1f-4613-b383-b52b22024ef4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2e072f63-0b1f-4613-b383-b52b22024ef4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

